### PR TITLE
Add streamEvent arn if required

### DIFF
--- a/packages/serverless-offline-dynamodb-streams/src/index.js
+++ b/packages/serverless-offline-dynamodb-streams/src/index.js
@@ -77,6 +77,7 @@ class ServerlessOfflineDynamoDBStreams {
       : streamEvent.arn;
 
     this.serverless.cli.log(`${arn}`);
+    streamEvent.arn = streamEvent.arn || arn;
 
     const {StreamDescription: {Shards: shards}} = await fromCallback(cb =>
       this.client.describeStream(


### PR DESCRIPTION
Stream ARN appears to be missing from DynamoDB-local streams. Added back in.