### PR TITLE
Allow for dynamic config options

### DIFF
--- a/packages/serverless-offline-kinesis/src/index.js
+++ b/packages/serverless-offline-kinesis/src/index.js
@@ -26,8 +26,6 @@ class ServerlessOfflineKinesis {
 
     this.commands = {};
 
-    this.client = new Kinesis(this.config);
-
     this.hooks = {
       'before:offline:start:init': this.offlineStartInit.bind(this),
       'before:offline:start:end': this.offlineStartEnd.bind(this)
@@ -83,6 +81,10 @@ class ServerlessOfflineKinesis {
     const streamName = streamEvent.arn.split('/')[1];
 
     this.serverless.cli.log(`${streamName}`);
+
+    if(!this.client) { 
+      this.client = new Kinesis(this.config); 
+    }
 
     const {StreamDescription: {Shards: shards}} = await fromCallback(cb =>
       this.client.describeStream(

--- a/packages/serverless-offline-kinesis/src/index.js
+++ b/packages/serverless-offline-kinesis/src/index.js
@@ -82,7 +82,7 @@ class ServerlessOfflineKinesis {
 
     this.serverless.cli.log(`${streamName}`);
 
-    if(!this.client) { 
+    if (!this.client) { 
       this.client = new Kinesis(this.config); 
     }
 


### PR DESCRIPTION
Problem: 
- this.config is set in constructor and it seems that by this time serverless as not converted the template into its final value. i.e none of those below like endpoint will actually be resolved.
```
  serverless-offline-kinesis:
    accessKeyId: root
    intervalMillis: 3000
    secretAccessKey: root
    apiVersion: '2013-12-02'
    region: ${self:custom.region}
    port: ${self:custom.kinesisPort}
    host: ${self:custom.protocol}${self:custom.host}
    endpoint: ${self:custom.protocol}${self:custom.host}:${self:custom.kinesisPort}
```

Solution:
- Moving the setting of this.client to later allows the options to have resolved to the correct variables