### PR TITLE
Return All attributes when receive message

### DIFF
--- a/packages/serverless-offline-sqs/src/index.js
+++ b/packages/serverless-offline-sqs/src/index.js
@@ -159,6 +159,7 @@ class ServerlessOfflineSQS {
           {
             QueueUrl,
             MaxNumberOfMessages: queueEvent.batchSize,
+            AttributeNames: ['All'],
             MessageAttributeNames: ['All'],
             WaitTimeSeconds: 1
           },


### PR DESCRIPTION
To consistent with SQS, return all attributes when receiving a message.